### PR TITLE
Feature: allows custom data in the batch

### DIFF
--- a/examples/batch_custom_data.py
+++ b/examples/batch_custom_data.py
@@ -1,0 +1,91 @@
+"""
+This is an example of how to extend the batch to include custom data
+"""
+
+from collections import defaultdict
+
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from functools import partial
+import numpy as np
+
+from trajdata import AgentBatch, AgentType, UnifiedDataset
+from trajdata.augmentation import NoiseHistories
+from trajdata.visualization.vis import plot_agent_batch
+
+def custom_random_data(batch_elem):
+    # create new data to add to the batch
+    return np.random.random((10, 10))
+
+def custom_goal_location(batch_elem):
+    # simply access existing element attributes
+    return batch_elem.agent_future_np[:, :2]
+
+def custom_min_distance_from_others(batch_elem):
+    # ... or more complicated calculations
+    current_ego_loc = batch_elem.agent_history_np[-1, :2]
+    all_distances = [np.linalg.norm(current_ego_loc - veh[-1, :2]) for veh in batch_elem.neighbor_histories]
+   
+    if not len(all_distances):
+        return np.inf
+    else:
+        return np.min(all_distances)
+
+def custom_distances_squared(batch_elem):
+    # we can chain extras together if needed
+    return batch_elem.extras["min_distance"] ** 2
+
+def custom_raster(batch_elem, raster_size):
+    # draw a custom raster
+    img = np.zeros(raster_size)
+
+    # ....
+    return img
+
+
+def main():
+    dataset = UnifiedDataset(
+        desired_data=["nusc_mini-mini_train"],
+        centric="agent",
+        desired_dt=0.1,
+        history_sec=(3.2, 3.2),
+        future_sec=(4.8, 4.8),
+        only_types=[AgentType.VEHICLE],
+        agent_interaction_distances=defaultdict(lambda: 30.0),
+        incl_robot_future=False,
+        incl_map=True,
+        map_params={"px_per_m": 2, "map_size_px": 224, "offset_frac_xy": (-0.5, 0.0)},
+        num_workers=0,
+        verbose=True,
+        data_dirs={  # Remember to change this to match your filesystem!
+            "nusc_mini": "~/datasets/nuScenes",
+        },
+        extras={ # a dictionary that contains functions that generate our custom data. Can be any function and has access to the batch element. 
+            "random_data": custom_random_data,
+            "goal_location": custom_goal_location,
+            "min_distance": custom_min_distance_from_others,
+            "min_distance_sq": custom_distances_squared, # in Python >= 3.7 dictionary is guaranteed to keep the order (you can use previously computed keys)
+            "raster": partial(custom_raster, raster_size=(100, 100))
+        }
+    )
+
+    print(f"# Data Samples: {len(dataset):,}")
+
+    dataloader = DataLoader(
+        dataset,
+        batch_size=4,
+        shuffle=True,
+        collate_fn=dataset.get_collate_fn(),
+        num_workers=4,
+    )
+
+    batch: AgentBatch
+    for batch in tqdm(dataloader):
+        assert "random_data" in batch.extras
+        assert "goal_location" in batch.extras
+        assert "min_distance" in batch.extras
+        assert "raster" in batch.extras
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trajdata/data_structures/batch.py
+++ b/src/trajdata/data_structures/batch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import torch
 from torch import Tensor
@@ -38,6 +38,7 @@ class AgentBatch:
     rasters_from_world_tf: Optional[Tensor]
     agents_from_world_tf: Tensor
     scene_ids: Optional[List]
+    extras: Dict[str, Tensor]
 
     def to(self, device) -> None:
         excl_vals = {
@@ -52,11 +53,15 @@ class AgentBatch:
             "num_neigh",
             "robot_fut_len",
             "scene_ids",
+            "extras",
         }
         for val in vars(self).keys():
             tensor_val = getattr(self, val)
             if val not in excl_vals and tensor_val is not None:
                 setattr(self, val, tensor_val.to(device))
+
+        for key, val in self.extras.items():
+            self.extras[key] = val.to(device)
 
     def agent_types(self) -> List[AgentType]:
         unique_types: Tensor = torch.unique(self.agent_type)
@@ -126,6 +131,7 @@ class SceneBatch:
     rasters_from_world_tf: Optional[Tensor]
     centered_agent_from_world_tf: Tensor
     centered_world_from_agent_tf: Tensor
+    extras: Dict[str, Tensor]
 
     def to(self, device) -> None:
         for val in vars(self).keys():

--- a/src/trajdata/data_structures/batch_element.py
+++ b/src/trajdata/data_structures/batch_element.py
@@ -130,6 +130,9 @@ class AgentBatchElement:
             self.map_patch = self.get_agent_map_patch(map_params)
 
         self.scene_id = scene_time_agent.scene.name
+        
+        # will be optionally populated by user's functions
+        self.extras = {}
 
     def get_agent_history(
         self,
@@ -400,6 +403,9 @@ class SceneBatchElement:
             # (whereas the above returns the current + future, yielding
             # one more timestep).
             self.robot_future_len: int = self.robot_future_np.shape[0] - 1
+
+        # will be optionally populated by user's functions
+        self.extras = {}
 
     def get_nearby_agents(
         self,

--- a/src/trajdata/data_structures/collation.py
+++ b/src/trajdata/data_structures/collation.py
@@ -478,6 +478,11 @@ def agent_collate_fn(
     )
 
     scene_ids = [batch_elem.scene_id for batch_elem in batch_elems]
+
+    extras: Dict[str, Tensor] = {}
+    for key in batch_elems[0].extras.keys():
+        extras[key] = torch.as_tensor(np.stack([batch_elem.extras[key] for batch_elem in batch_elems]))
+
     batch = AgentBatch(
         data_idx=data_index_t,
         dt=dt_t,
@@ -505,6 +510,7 @@ def agent_collate_fn(
         rasters_from_world_tf=rasters_from_world_tf,
         agents_from_world_tf=agents_from_world_tf,
         scene_ids=scene_ids,
+        extras=extras,
     )
 
     if batch_augments:
@@ -724,6 +730,10 @@ def scene_collate_fn(
         else None
     )
 
+    extras: Dict[str, Tensor] = {}
+    for key in batch_elems[0].extras.keys():
+        extras[key] = torch.as_tensor(np.stack([batch_elem.extras[key] for batch_elem in batch_elems]))
+
     batch = SceneBatch(
         data_idx=data_index_t,
         dt=dt_t,
@@ -743,6 +753,7 @@ def scene_collate_fn(
         rasters_from_world_tf=rasters_from_world_tf,
         centered_agent_from_world_tf=centered_agent_from_world_tf,
         centered_world_from_agent_tf=centered_world_from_agent_tf,
+        extras=extras,
     )
 
     if batch_augments:

--- a/src/trajdata/dataset.py
+++ b/src/trajdata/dataset.py
@@ -82,6 +82,7 @@ class UnifiedDataset(Dataset):
         rebuild_maps: bool = False,
         num_workers: int = 0,
         verbose: bool = False,
+        extras: Dict[str, Callable] = {},
     ) -> None:
         """Instantiates a PyTorch Dataset object which aggregates data
         from multiple trajectory forecasting datasets.
@@ -110,6 +111,7 @@ class UnifiedDataset(Dataset):
             rebuild_maps (bool, optional): If True, process and cache maps even if they are already cached. Defaults to False.
             num_workers (int, optional): Number of parallel workers to use for dataset preprocessing and loading. Defaults to 0.
             verbose (bool, optional):  If True, print internal data loading information. Defaults to False.
+            extras (Dict[str, Callable]: Used to add extra data to a batch element. The callable function will be provided with an initialised batch element and should return the data. 
         """
         self.centric: str = centric
         self.desired_dt: float = desired_dt
@@ -141,6 +143,7 @@ class UnifiedDataset(Dataset):
         self.standardize_data = standardize_data
         self.standardize_derivatives = standardize_derivatives
         self.augmentations = augmentations
+        self.extras = extras
         self.verbose = verbose
         self.max_agent_num = max_agent_num
 
@@ -609,7 +612,7 @@ class UnifiedDataset(Dataset):
                 only_types=self.only_types,
                 no_types=self.no_types,
             )
-            return SceneBatchElement(
+            batch_element: SceneBatchElement = SceneBatchElement(
                 scene_cache,
                 idx,
                 scene_time,
@@ -634,7 +637,7 @@ class UnifiedDataset(Dataset):
                 incl_robot_future=self.incl_robot_future,
             )
 
-            return AgentBatchElement(
+            batch_element: AgentBatchElement = AgentBatchElement(
                 scene_cache,
                 idx,
                 scene_time_agent,
@@ -647,3 +650,9 @@ class UnifiedDataset(Dataset):
                 self.standardize_data,
                 self.standardize_derivatives,
             )
+
+        for key, func in self.extras.items():
+            batch_element.extras[key] = func(batch_element)
+
+        return batch_element
+


### PR DESCRIPTION
As discussed. However, it currently does not allow for a custom collate function (now just uses np.stack, which assumes identical array sizes across batch elements).  
I also added `batch_custom_data.py` example file under examples/

Adding custom collate should be simple enough, but I am worried it might complicate the API.
For example, we could have extras be a Dict[str, Tuple[Callable, Callable]] (the second callable is custom collate), or have another extras_collate_fns (but this might require the user to double-check its dictionary keys and might create a lot of boilerplate). We can leave it for now, or if you have any thoughts we can work on it.

Let me know of any needed changes.