### PR TITLE
small fix on raster map querying for scene-centric data batch

### DIFF
--- a/src/trajdata/data_structures/batch_element.py
+++ b/src/trajdata/data_structures/batch_element.py
@@ -546,6 +546,7 @@ class SceneBatchElement:
                 offset_xy,
                 heading[i],
                 return_rgb,
+                rot_pad_factor=sqrt(2),
                 no_map_val=no_map_fill_val,
             )
             map_patches.append(

--- a/src/trajdata/utils/state_utils.py
+++ b/src/trajdata/utils/state_utils.py
@@ -126,7 +126,7 @@ def transform_from_frame(
     attributes = state._format_dict.keys()
 
     frame_heading = frame_state.heading[..., 0]
-    if rot_mat is not None:
+    if rot_mat is None:
         rot_mat = rotation_matrix(frame_heading)
 
     if "x" in attributes and "y" in attributes:


### PR DESCRIPTION
This small fix makes the `maps` in scene-centric data loading mode and that in data-centric data loading mode consistent.