### PR TITLE
Fix typo in `test_vec_map.py`

### DIFF
--- a/tests/test_vec_map.py
+++ b/tests/test_vec_map.py
@@ -52,7 +52,7 @@ class TestVectorMap(unittest.TestCase):
 
 def maps_equal(map1: VectorMap, map2: VectorMap) -> bool:
     elements1_set = set([elem.id for elem in map1.iter_elems()])
-    elements2_set = set([elem.id for elem in map1.iter_elems()])
+    elements2_set = set([elem.id for elem in map2.iter_elems()])
     return elements1_set == elements2_set
 
 


### PR DESCRIPTION
I found a typo in the `test_vec_map.py` - this will fix it.

Best
Alex