### PR TITLE
change the subfolder name of nuplan to make data structure in DATASET…

### DIFF
--- a/src/trajdata/dataset_specific/nuplan/nuplan_dataset.py
+++ b/src/trajdata/dataset_specific/nuplan/nuplan_dataset.py
@@ -74,9 +74,9 @@ class NuplanDataset(RawDataset):
             print(f"Loading {self.name} dataset...", flush=True)
 
         if self.name == "nuplan_mini":
-            subfolder = "mini"
+            subfolder = "dataset/nuplan-v1.1/mini"
         elif self.name.startswith("nuplan"):
-            subfolder = "trainval"
+            subfolder = "dataset/nuplan-v1.1/trainval"
 
         self.dataset_obj = nuplan_utils.NuPlanObject(self.metadata.data_dir, subfolder)
 


### PR DESCRIPTION
it seems that the subfolder name of nuplan dataset does not match the data structure mentioned in DATASETS.md. The structure in DATASETS.md is 
```
path_to_data/dataset/nuplan-v1.1/mini
```
but the folder path passed to nuplan_utils.NuPlanObject is
```
path_to_data/mini
```