### PR TITLE
fix: fail to load cached datasets

### DIFF
--- a/src/trajdata/dataset.py
+++ b/src/trajdata/dataset.py
@@ -369,7 +369,7 @@ class UnifiedDataset(Dataset):
             print(f"Loading cache from {cache_path} ...", end="")
             t = time.time()
             with open(cache_path, "rb") as f:
-                self._cached_batch_elements, keep_mask = dill.load(f, encoding="latin1")
+                self._cached_batch_elements, keep_ids = dill.load(f, encoding="latin1")
             print(f" done in {time.time() - t:.1f}s.")
 
         else:


### PR DESCRIPTION
Hi, 

This pull request is related to Issue #32.
load_or_create_cache function fails to load the cached dataset due to the different variable names.

Please consider accepting this pull request for convenience.