### PR TITLE
Add Av2 Motion Forecasting dataset

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -188,3 +188,30 @@ It should look like this after downloading:
 ```
 
 **Note**: Only the annotations need to be downloaded (not the videos).
+
+
+## Argoverse 2 Motion Forecasting
+The dataset can be downloaded from [here](https://www.argoverse.org/av2.html#download-link).
+
+It should look like this after downloading:
+```
+/path/to/av2mf/
+            ├── train/
+            |   ├── 0000b0f9-99f9-4a1f-a231-5be9e4c523f7/
+            |   |   ├── log_map_archive_0000b0f9-99f9-4a1f-a231-5be9e4c523f7.json
+            |   |   └── scenario_0000b0f9-99f9-4a1f-a231-5be9e4c523f7.parquet
+            |   ├── 0000b6ab-e100-4f6b-aee8-b520b57c0530/
+            |   |   ├── log_map_archive_0000b6ab-e100-4f6b-aee8-b520b57c0530.json
+            |   |   └── scenario_0000b6ab-e100-4f6b-aee8-b520b57c0530.parquet
+            |   └── ...
+            ├── val/
+            |   ├── 00010486-9a07-48ae-b493-cf4545855937/
+            |   |   ├── log_map_archive_00010486-9a07-48ae-b493-cf4545855937.json
+            |   |   └── scenario_00010486-9a07-48ae-b493-cf4545855937.parquet
+            |   └── ...
+            └── test/
+                ├── 0000b329-f890-4c2b-93f2-7e2413d4ca5b/
+                |   ├── log_map_archive_0000b329-f890-4c2b-93f2-7e2413d4ca5b.json
+                |   └── scenario_0000b329-f890-4c2b-93f2-7e2413d4ca5b.parquet
+                └── ...
+```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Currently, the dataloader supports interfacing with the following datasets:
 | Lyft Level 5 Train Full | `lyft_train_full` | `train` | `palo_alto` | Lyft Level 5 training data - part 2/2 (70 GB) | 0.1s (10Hz) | :white_check_mark: |
 | Lyft Level 5 Validation | `lyft_val` | `val` | `palo_alto` | Lyft Level 5 validation data (8.2 GB) | 0.1s (10Hz) | :white_check_mark: |
 | Lyft Level 5 Sample | `lyft_sample` | `mini_train`, `mini_val` | `palo_alto` | Lyft Level 5 sample data (100 scenes, randomly split 80/20 for training/validation) | 0.1s (10Hz) | :white_check_mark: |
-| Argoverse 2 Motion Forecasting | `av2_motion_forecasting` | `train`, `val`, `test` | | 250,000 motion forecasting scenarios of 11s each | 0.1s (10Hz) | :white_check_mark: |
+| Argoverse 2 Motion Forecasting | `av2_motion_forecasting` | `train`, `val`, `test` | N/A | 250,000 motion forecasting scenarios of 11s each | 0.1s (10Hz) | :white_check_mark: |
 | INTERACTION Dataset Single-Agent | `interaction_single` | `train`, `val`, `test`, `test_conditional` | `usa`, `china`, `germany`, `bulgaria` | Single-agent split of the INTERACTION Dataset (where the goal is to predict one target agents' future motion) | 0.1s (10Hz) | :white_check_mark: |
 | INTERACTION Dataset Multi-Agent | `interaction_multi` | `train`, `val`, `test`, `test_conditional` | `usa`, `china`, `germany`, `bulgaria` | Multi-agent split of the INTERACTION Dataset (where the goal is to jointly predict multiple agents' future motion) | 0.1s (10Hz) | :white_check_mark: |
 | ETH - Univ | `eupeds_eth` | `train`, `val`, `train_loo`, `val_loo`, `test_loo` | `zurich` | The ETH (University) scene from the ETH BIWI Walking Pedestrians dataset | 0.4s (2.5Hz) | |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Currently, the dataloader supports interfacing with the following datasets:
 | Lyft Level 5 Train Full | `lyft_train_full` | `train` | `palo_alto` | Lyft Level 5 training data - part 2/2 (70 GB) | 0.1s (10Hz) | :white_check_mark: |
 | Lyft Level 5 Validation | `lyft_val` | `val` | `palo_alto` | Lyft Level 5 validation data (8.2 GB) | 0.1s (10Hz) | :white_check_mark: |
 | Lyft Level 5 Sample | `lyft_sample` | `mini_train`, `mini_val` | `palo_alto` | Lyft Level 5 sample data (100 scenes, randomly split 80/20 for training/validation) | 0.1s (10Hz) | :white_check_mark: |
+| Argoverse 2 Motion Forecasting | `av2_motion_forecasting` | `train`, `val`, `test` | | 250,000 motion forecasting scenarios of 11s each | 0.1s (10Hz) | :white_check_mark: |
 | INTERACTION Dataset Single-Agent | `interaction_single` | `train`, `val`, `test`, `test_conditional` | `usa`, `china`, `germany`, `bulgaria` | Single-agent split of the INTERACTION Dataset (where the goal is to predict one target agents' future motion) | 0.1s (10Hz) | :white_check_mark: |
 | INTERACTION Dataset Multi-Agent | `interaction_multi` | `train`, `val`, `test`, `test_conditional` | `usa`, `china`, `germany`, `bulgaria` | Multi-agent split of the INTERACTION Dataset (where the goal is to jointly predict multiple agents' future motion) | 0.1s (10Hz) | :white_check_mark: |
 | ETH - Univ | `eupeds_eth` | `train`, `val`, `train_loo`, `val_loo`, `test_loo` | `zurich` | The ETH (University) scene from the ETH BIWI Walking Pedestrians dataset | 0.4s (2.5Hz) | |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+av2 = ["av2==0.2.1"]
 dev = ["black", "isort", "pytest", "pytest-xdist", "twine", "build"]
 interaction = ["lanelet2==1.2.1"]
 lyft = ["l5kit==1.5.0"]

--- a/src/trajdata/dataset_specific/argoverse2/__init__.py
+++ b/src/trajdata/dataset_specific/argoverse2/__init__.py
@@ -1,0 +1,1 @@
+from .av2_dataset import Av2Dataset

--- a/src/trajdata/dataset_specific/argoverse2/av2_dataset.py
+++ b/src/trajdata/dataset_specific/argoverse2/av2_dataset.py
@@ -3,6 +3,11 @@ from typing import Any, Dict, List, Tuple, Type
 
 import pandas as pd
 import tqdm
+from av2.datasets.motion_forecasting.constants import (
+    AV2_SCENARIO_OBS_TIMESTEPS,
+    AV2_SCENARIO_STEP_HZ,
+    AV2_SCENARIO_TOTAL_TIMESTEPS,
+)
 
 from trajdata.caching.env_cache import EnvCache
 from trajdata.caching.scene_cache import SceneCache
@@ -21,9 +26,7 @@ from trajdata.dataset_specific.scene_records import Argoverse2Record
 from trajdata.utils import arr_utils
 
 AV2_MOTION_FORECASTING = "av2_motion_forecasting"
-AV2_DT = 0.1
-AV2_N_TIMESTEPS_TRAINVAL = 110
-AV2_N_TIMESTEPS_TEST = 50
+AV2_DT = 1 / AV2_SCENARIO_STEP_HZ
 
 
 class Av2Dataset(RawDataset):
@@ -104,9 +107,9 @@ class Av2Dataset(RawDataset):
             location=scenario_name,
             data_split=data_split,
             length_timesteps=(
-                AV2_N_TIMESTEPS_TEST
+                AV2_SCENARIO_OBS_TIMESTEPS
                 if data_split == "test"
-                else AV2_N_TIMESTEPS_TRAINVAL
+                else AV2_SCENARIO_TOTAL_TIMESTEPS
             ),
             raw_data_idx=data_idx,
             data_access_info=None,
@@ -141,7 +144,7 @@ class Av2Dataset(RawDataset):
 
                 df_records.append(
                     {
-                        "agent_id": track.track_id,
+                        "agent_id": track_metadata.name,
                         "scene_ts": object_state.timestep,
                         "x": object_state.position[0],
                         "y": object_state.position[1],

--- a/src/trajdata/dataset_specific/argoverse2/av2_dataset.py
+++ b/src/trajdata/dataset_specific/argoverse2/av2_dataset.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Type
+
+import pandas as pd
+import tqdm
+
+from trajdata.caching.env_cache import EnvCache
+from trajdata.caching.scene_cache import SceneCache
+from trajdata.data_structures import AgentMetadata, EnvMetadata, Scene, SceneMetadata
+from trajdata.data_structures.scene_tag import SceneTag
+from trajdata.dataset_specific.argoverse2.av2_utils import (
+    AV2_SPLITS,
+    Av2Object,
+    Av2ScenarioIds,
+    av2_map_to_vector_map,
+    get_track_metadata,
+    scenario_name_to_split,
+)
+from trajdata.dataset_specific.raw_dataset import RawDataset
+from trajdata.dataset_specific.scene_records import Argoverse2Record
+from trajdata.utils import arr_utils
+
+AV2_MOTION_FORECASTING = "av2_motion_forecasting"
+AV2_DT = 0.1
+AV2_N_TIMESTEPS_TRAINVAL = 110
+AV2_N_TIMESTEPS_TEST = 50
+
+
+class Av2Dataset(RawDataset):
+
+    def compute_metadata(self, env_name: str, data_dir: str) -> EnvMetadata:
+        if env_name != AV2_MOTION_FORECASTING:
+            raise ValueError(f"Unknown Argoverse 2 env name: {env_name}")
+
+        scenario_ids = Av2ScenarioIds.create(Path(data_dir))
+
+        return EnvMetadata(
+            name=env_name,
+            data_dir=data_dir,
+            dt=AV2_DT,
+            parts=[AV2_SPLITS],
+            scene_split_map=scenario_ids.scene_split_map,
+            map_locations=None,
+        )
+
+    def load_dataset_obj(self, verbose: bool = False) -> None:
+        if verbose:
+            print(f"Loading {self.name} dataset...", flush=True)
+        self.dataset_obj = Av2Object(self.metadata.data_dir)
+
+    def _get_matching_scenes_from_obj(
+        self,
+        scene_tag: SceneTag,
+        scene_desc_contains: List[str] | None,
+        env_cache: EnvCache,
+    ) -> List[SceneMetadata]:
+        """Compute SceneMetadata for all samples from self.dataset_obj.
+
+        Also saves records to env_cache for later reuse.
+        """
+        if scene_desc_contains:
+            raise ValueError("Argoverse dataset does not support scene descriptions.")
+
+        record_list = []
+        metadata_list = []
+
+        for idx, scenario_name in enumerate(self.dataset_obj.scenario_names):
+            record_list.append(Argoverse2Record(scenario_name, idx))
+            metadata_list.append(
+                SceneMetadata(
+                    env_name=self.metadata.name,
+                    name=scenario_name,
+                    dt=AV2_DT,
+                    raw_data_idx=idx,
+                )
+            )
+
+        self.cache_all_scenes_list(env_cache, record_list)
+        return metadata_list
+
+    def _get_matching_scenes_from_cache(
+        self,
+        scene_tag: SceneTag,
+        scene_desc_contains: List[str] | None,
+        env_cache: EnvCache,
+    ) -> List[Scene]:
+        """Computes Scene data for all samples by reading data from env_cache."""
+        if scene_desc_contains:
+            raise ValueError("Argoverse dataset does not support scene descriptions.")
+
+        record_list: List[Argoverse2Record] = env_cache.load_env_scenes_list(self.name)
+        return [
+            self._create_scene(record.name, record.data_idx) for record in record_list
+        ]
+
+    def get_scene(self, scene_info: SceneMetadata) -> Scene:
+        return self._create_scene(scene_info.name, scene_info.raw_data_idx)
+
+    def _create_scene(self, scenario_name: str, data_idx: int) -> Scene:
+        data_split = scenario_name_to_split(scenario_name)
+        return Scene(
+            env_metadata=self.metadata,
+            name=scenario_name,
+            location=scenario_name,
+            data_split=data_split,
+            length_timesteps=(
+                AV2_N_TIMESTEPS_TEST
+                if data_split == "test"
+                else AV2_N_TIMESTEPS_TRAINVAL
+            ),
+            raw_data_idx=data_idx,
+            data_access_info=None,
+        )
+
+    def get_agent_info(
+        self, scene: Scene, cache_path: Path, cache_class: Type[SceneCache]
+    ) -> Tuple[List[AgentMetadata], List[List[AgentMetadata]]]:
+        """
+        Get frame-level information from source dataset, caching it
+        to cache_path.
+
+        Always called after cache_maps, can load map if needed
+        to associate map information to positions.
+        """
+        scenario = self.dataset_obj.load_scenario(scene.name)
+
+        agent_list: List[AgentMetadata] = []
+        agent_presence: List[List[AgentMetadata]] = [[] for _ in scenario.timestamps_ns]
+
+        df_records = []
+
+        for track in scenario.tracks:
+            track_metadata = get_track_metadata(track)
+            if track_metadata is None:
+                continue
+
+            agent_list.append(track_metadata)
+
+            for object_state in track.object_states:
+                agent_presence[int(object_state.timestep)].append(track_metadata)
+
+                df_records.append(
+                    {
+                        "agent_id": track.track_id,
+                        "scene_ts": object_state.timestep,
+                        "x": object_state.position[0],
+                        "y": object_state.position[1],
+                        "z": 0.0,
+                        "vx": object_state.velocity[0],
+                        "vy": object_state.velocity[1],
+                        "heading": object_state.heading,
+                    }
+                )
+
+        df = pd.DataFrame.from_records(df_records)
+        df.set_index(["agent_id", "scene_ts"], inplace=True)
+        df.sort_index(inplace=True)
+
+        df[["ax", "ay"]] = (
+            arr_utils.agent_aware_diff(
+                df[["vx", "vy"]].to_numpy(), df.index.get_level_values(0)
+            )
+            / AV2_DT
+        )
+        cache_class.save_agent_data(df, cache_path, scene)
+
+        return agent_list, agent_presence
+
+    def cache_maps(
+        self,
+        cache_path: Path,
+        map_cache_class: Type[SceneCache],
+        map_params: Dict[str, Any],
+    ) -> None:
+        """
+        Get static, scene-level info from the source dataset, caching it
+        to cache_path. (Primarily this is info needed to construct VectorMap)
+
+        Resolution is in pixels per meter.
+        """
+        for scenario_name in tqdm.tqdm(
+            self.dataset_obj.scenario_names,
+            desc=f"{self.name} cache maps",
+            dynamic_ncols=True,
+        ):
+            av2_map = self.dataset_obj.load_map(scenario_name)
+            vector_map = av2_map_to_vector_map(f"{self.name}:{scenario_name}", av2_map)
+            map_cache_class.finalize_and_cache_map(cache_path, vector_map, map_params)

--- a/src/trajdata/dataset_specific/argoverse2/av2_utils.py
+++ b/src/trajdata/dataset_specific/argoverse2/av2_utils.py
@@ -234,8 +234,13 @@ def get_track_metadata(track: Track) -> Optional[AgentMetadata]:
     if not timesteps:
         return None
 
+    # Av2 uses the name "AV" for the robot. Trajdata expects the name "ego" for the robot.
+    name = track.track_id
+    if name == "AV":
+        name = "ego"
+
     return AgentMetadata(
-        name=track.track_id,
+        name=name,
         agent_type=agent_type,
         first_timestep=min(timesteps),
         last_timestep=max(timesteps),

--- a/src/trajdata/dataset_specific/argoverse2/av2_utils.py
+++ b/src/trajdata/dataset_specific/argoverse2/av2_utils.py
@@ -1,0 +1,250 @@
+import dataclasses
+import os
+from pathlib import Path
+from typing import Dict, Literal, Optional, Tuple
+
+import numpy as np
+from av2.datasets.motion_forecasting.data_schema import (
+    ArgoverseScenario,
+    ObjectType,
+    Track,
+)
+from av2.datasets.motion_forecasting.scenario_serialization import (
+    load_argoverse_scenario_parquet,
+)
+from av2.datasets.motion_forecasting.viz.scenario_visualization import (
+    _ESTIMATED_CYCLIST_LENGTH_M,
+    _ESTIMATED_CYCLIST_WIDTH_M,
+    _ESTIMATED_VEHICLE_LENGTH_M,
+    _ESTIMATED_VEHICLE_WIDTH_M,
+)
+from av2.geometry.interpolate import compute_midpoint_line
+from av2.map.map_api import ArgoverseStaticMap
+
+from trajdata.data_structures.agent import AgentMetadata, AgentType, FixedExtent
+from trajdata.maps.vec_map import VectorMap
+from trajdata.maps.vec_map_elements import PedCrosswalk, Polyline, RoadArea, RoadLane
+
+AV2_SPLITS = ("train", "val", "test")
+DELIM = "_"
+T_Split = Literal["train", "val", "test"]
+
+
+# {ObjectType: (AgentType, length, width, height)}.
+# Uses av2 constants where possible.
+OBJECT_TYPE_DATA: Dict[str, Tuple[AgentType, float, float, float]] = {
+    ObjectType.VEHICLE: (
+        AgentType.VEHICLE,
+        _ESTIMATED_VEHICLE_LENGTH_M,
+        _ESTIMATED_VEHICLE_WIDTH_M,
+        2,
+    ),
+    ObjectType.PEDESTRIAN: (AgentType.PEDESTRIAN, 0.7, 0.7, 2),
+    ObjectType.MOTORCYCLIST: (
+        AgentType.MOTORCYCLE,
+        _ESTIMATED_CYCLIST_LENGTH_M,
+        _ESTIMATED_CYCLIST_WIDTH_M,
+        2,
+    ),
+    ObjectType.CYCLIST: (
+        AgentType.BICYCLE,
+        _ESTIMATED_CYCLIST_LENGTH_M,
+        _ESTIMATED_CYCLIST_WIDTH_M,
+        2,
+    ),
+    ObjectType.BUS: (AgentType.VEHICLE, 9, 3, 4),
+}
+
+
+@dataclasses.dataclass
+class Av2ScenarioIds:
+    train: list[str]
+    val: list[str]
+    test: list[str]
+
+    @staticmethod
+    def create(dataset_path: Path) -> "Av2ScenarioIds":
+        train = os.listdir(dataset_path / "train")
+        val = os.listdir(dataset_path / "val")
+        test = os.listdir(dataset_path / "test")
+        return Av2ScenarioIds(train=train, val=val, test=test)
+
+    @property
+    def scene_split_map(self) -> Dict[str, T_Split]:
+        """Compute a map of {scenario_name: split}."""
+        return {
+            _pack_av2_scenario_name(split, scenario_id): split
+            for split, scenario_ids in dataclasses.asdict(self).items()
+            for scenario_id in scenario_ids
+        }
+
+
+def scenario_name_to_split(scenario_name: str) -> T_Split:
+    split, _ = _unpack_av2_scenario_name(scenario_name)
+    return split
+
+
+def _pack_av2_scenario_name(split: T_Split, scenario_id: str) -> str:
+    return split + DELIM + scenario_id
+
+
+def _unpack_av2_scenario_name(scenario_name: str) -> Tuple[T_Split, str]:
+    return tuple(scenario_name.split(DELIM, maxsplit=1))
+
+
+def _scenario_df_filename(scenario_id: str) -> str:
+    return f"scenario_{scenario_id}.parquet"
+
+
+def _scenario_map_filename(scenario_id: str) -> str:
+    return f"log_map_archive_{scenario_id}.json"
+
+
+class Av2Object:
+    """Object for interfacing with Av2 data on disk."""
+
+    def __init__(self, dataset_path: Path) -> None:
+        self.dataset_path = dataset_path
+        self.scenario_ids = Av2ScenarioIds.create(dataset_path)
+
+    @property
+    def scenario_names(self) -> list[str]:
+        return list(self.scenario_ids.scene_split_map)
+
+    def _parse_scenario_name(self, scenario_name: str) -> Tuple[Path, str]:
+        split, scenario_id = _unpack_av2_scenario_name(scenario_name)
+        del scenario_name
+
+        scenario_dir = self.dataset_path / split / scenario_id
+        if not scenario_dir.exists():
+            raise FileNotFoundError(f"Scenario path {scenario_dir} not found")
+        return scenario_dir, scenario_id
+
+    def load_scenario(self, scenario_name: str) -> ArgoverseScenario:
+        scenario_dir, scenario_id = self._parse_scenario_name(scenario_name)
+        return load_argoverse_scenario_parquet(
+            scenario_dir / _scenario_df_filename(scenario_id)
+        )
+
+    def load_map(self, scenario_name: str) -> ArgoverseStaticMap:
+        scenario_dir, scenario_id = self._parse_scenario_name(scenario_name)
+        return ArgoverseStaticMap.from_json(
+            scenario_dir / _scenario_map_filename(scenario_id)
+        )
+
+
+def av2_map_to_vector_map(map_id: str, av2_map: ArgoverseStaticMap) -> VectorMap:
+    vector_map = VectorMap(map_id)
+
+    extents: Optional[Tuple[np.ndarray, np.ndarray]] = None
+
+    for lane_segment in av2_map.vector_lane_segments.values():
+        lane_max = np.maximum(
+            lane_segment.left_lane_boundary.xyz.max(0),
+            lane_segment.right_lane_boundary.xyz.max(0),
+        )
+        lane_min = np.minimum(
+            lane_segment.left_lane_boundary.xyz.min(0),
+            lane_segment.right_lane_boundary.xyz.min(0),
+        )
+
+        if extents is None:
+            extents = (lane_min, lane_max)
+        else:
+            extents = (
+                np.minimum(lane_min, extents[0]),
+                np.maximum(lane_max, extents[1]),
+            )
+
+        center, _ = compute_midpoint_line(
+            lane_segment.left_lane_boundary.xyz, lane_segment.right_lane_boundary.xyz
+        )
+        vector_map.add_map_element(
+            RoadLane(
+                id=_road_lane_id(lane_segment.id),
+                center=Polyline(center),
+                left_edge=Polyline(lane_segment.left_lane_boundary.xyz),
+                right_edge=Polyline(lane_segment.right_lane_boundary.xyz),
+                adj_lanes_left=_adj_lanes_set(lane_segment.left_neighbor_id),
+                adj_lanes_right=_adj_lanes_set(lane_segment.right_neighbor_id),
+                next_lanes={_road_lane_id(i) for i in lane_segment.successors},
+                prev_lanes={_road_lane_id(i) for i in lane_segment.predecessors},
+            )
+        )
+
+    for drivavble_area in av2_map.vector_drivable_areas.values():
+        assert extents is not None
+        extents = (
+            np.minimum(drivavble_area.xyz.min(0), extents[0]),
+            np.maximum(drivavble_area.xyz.max(0), extents[1]),
+        )
+
+        vector_map.add_map_element(
+            RoadArea(
+                id=_road_area_id(drivavble_area.id),
+                exterior_polygon=Polyline(drivavble_area.xyz),
+            )
+        )
+
+    for ped_crossing in av2_map.vector_pedestrian_crossings.values():
+        assert extents is not None
+        extents = (
+            np.minimum(ped_crossing.polygon.min(0), extents[0]),
+            np.maximum(ped_crossing.polygon.max(0), extents[1]),
+        )
+        vector_map.add_map_element(
+            PedCrosswalk(
+                id=_ped_crosswalk_id(ped_crossing.id),
+                polygon=Polyline(ped_crossing.polygon),
+            )
+        )
+
+    # extent is [min_x, min_y, min_z, max_x, max_y, max_z]
+    vector_map.extent = np.concatenate(extents)
+
+    return vector_map
+
+
+def _adj_lanes_set(neighbor_id: Optional[int]) -> set[str]:
+    if neighbor_id is None:
+        return set()
+    return {_road_lane_id(neighbor_id)}
+
+
+def _road_lane_id(lane_segment_id: int) -> str:
+    return f"RoadLane{lane_segment_id}"
+
+
+def _road_area_id(drivable_area_id: int) -> str:
+    return f"RoadArea{drivable_area_id}"
+
+
+def _ped_crosswalk_id(ped_crossing_id: int) -> str:
+    return f"PedCrosswalk{ped_crossing_id}"
+
+
+def get_track_metadata(track: Track) -> Optional[AgentMetadata]:
+    agent_data = OBJECT_TYPE_DATA.get(track.object_type)
+    if agent_data is None:
+        return None
+
+    agent_type, length, width, height = agent_data
+
+    timesteps = [_to_int(state.timestep) for state in track.object_states]
+    if not timesteps:
+        return None
+
+    return AgentMetadata(
+        name=track.track_id,
+        agent_type=agent_type,
+        first_timestep=min(timesteps),
+        last_timestep=max(timesteps),
+        extent=FixedExtent(length=length, width=width, height=height),
+    )
+
+
+def _to_int(x: float) -> int:
+    """Safe convert floats like 42.0 to 42."""
+    y = int(x)
+    assert x == y
+    return y

--- a/src/trajdata/dataset_specific/scene_records.py
+++ b/src/trajdata/dataset_specific/scene_records.py
@@ -1,6 +1,11 @@
 from typing import NamedTuple
 
 
+class Argoverse2Record(NamedTuple):
+    name: str
+    data_idx: int
+
+
 class EUPedsRecord(NamedTuple):
     name: str
     location: str

--- a/src/trajdata/utils/env_utils.py
+++ b/src/trajdata/utils/env_utils.py
@@ -45,6 +45,11 @@ def get_raw_dataset(dataset_name: str, data_dir: str) -> RawDataset:
             dataset_name, data_dir, parallelizable=True, has_maps=True
         )
 
+    if "av2" in dataset_name:
+        from trajdata.dataset_specific.argoverse2 import Av2Dataset
+
+        return Av2Dataset(dataset_name, data_dir, parallelizable=True, has_maps=True)
+
     raise ValueError(f"Dataset with name '{dataset_name}' is not supported")
 
 


### PR DESCRIPTION
Adds support for the [Argoverse2 Motion Forecasting dataset](https://www.argoverse.org/av2.html#forecasting-link) with trajdata. I tested it by running several of the example scripts (e.g. `preprocess_data.py`, `visualization_example.py`).