### PR TITLE
Add View-of-Delft Prediction dataset 

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -1,5 +1,16 @@
 # Supported Datasets and Required Formats
 
+## View-of-Delft 
+Nothing special needs to be done for the View-of-Delft Prediction dataset, simply download it as per [the instructions in the devkit README](https://github.com/tudelft-iv/view-of-delft-prediction-devkit?tab=readme-ov-file#vod-p-setup).
+
+It should look like this after downloading:
+```
+/path/to/VoD/
+            ├── maps/
+            ├── v1.0-test/
+            └── v1.0-trainval/
+```
+
 ## nuScenes
 Nothing special needs to be done for the nuScenes dataset, simply download it as per [the instructions in the devkit README](https://github.com/nutonomy/nuscenes-devkit#nuscenes-setup).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The easiest way to install trajdata is through PyPI with
 pip install trajdata
 ```
 
-In case you would also like to use datasets such as nuScenes, Lyft Level 5, or Waymo Open Motion Dataset (which require their own devkits to access raw data or additional package dependencies), the following will also install the respective devkits and/or package dependencies.
+In case you would also like to use datasets such as nuScenes, Lyft Level 5, View-of-Delft, or Waymo Open Motion Dataset (which require their own devkits to access raw data or additional package dependencies), the following will also install the respective devkits and/or package dependencies.
 ```sh
 # For nuScenes
 pip install "trajdata[nusc]"
@@ -31,10 +31,13 @@ pip install "trajdata[waymo]"
 # For INTERACTION
 pip install "trajdata[interaction]"
 
+# For View-of-Delft
+pip install "trajdata[vod]"
+
 # All
-pip install "trajdata[nusc,lyft,waymo,interaction]"
+pip install "trajdata[nusc,vod,lyft,waymo,interaction]"
 ```
-Then, download the raw datasets (nuScenes, Lyft Level 5, ETH/UCY, etc.) in case you do not already have them. For more information about how to structure dataset folders/files, please see [`DATASETS.md`](./DATASETS.md).
+Then, download the raw datasets (nuScenes, Lyft Level 5, View-of-Delft, ETH/UCY, etc.) in case you do not already have them. For more information about how to structure dataset folders/files, please see [`DATASETS.md`](./DATASETS.md).
 
 ### Package Developer Installation
 
@@ -100,6 +103,8 @@ Currently, the dataloader supports interfacing with the following datasets:
 | nuPlan Validation | `nuplan_val` | N/A | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan validation split (90.30 GB) | 0.05s (20Hz) | :white_check_mark: |
 | nuPlan Test | `nuplan_test` | N/A | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan testing split (89.33 GB) | 0.05s (20Hz) | :white_check_mark: |
 | nuPlan Mini | `nuplan_mini` | `mini_train`, `mini_val`, `mini_test` | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan mini training/validation/test splits (942/197/224 scenes, 7.96 GB) | 0.05s (20Hz) | :white_check_mark: |
+| View-of-Delft Train/TrainVal/Val | `nusc_trainval` | `train`, `train_val`, `val` | `delft` | View-of-Delft Prediction training and validation splits | 0.1s (10Hz) | :white_check_mark: |
+| View-of-Delft Test | `nusc_test` | `test` | `delft` | View-of-Delft test split, with annotations | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Training | `waymo_train` | `train` | N/A | Waymo Open Motion Dataset `training` split | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Validation | `waymo_val` | `val` | N/A | Waymo Open Motion Dataset `validation` split | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Testing | `waymo_test` | `test` | N/A | Waymo Open Motion Dataset `testing` split | 0.1s (10Hz) | :white_check_mark: |

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ pip install "trajdata[waymo]"
 # For INTERACTION
 pip install "trajdata[interaction]"
 
-# For View-of-Delft
+# For View-of-Delft 
 pip install "trajdata[vod]"
 
 # All
-pip install "trajdata[nusc,vod,lyft,waymo,interaction]"
+pip install "trajdata[nusc,lyft,waymo,interaction,vod]"
 ```
 Then, download the raw datasets (nuScenes, Lyft Level 5, View-of-Delft, ETH/UCY, etc.) in case you do not already have them. For more information about how to structure dataset folders/files, please see [`DATASETS.md`](./DATASETS.md).
 
@@ -103,8 +103,8 @@ Currently, the dataloader supports interfacing with the following datasets:
 | nuPlan Validation | `nuplan_val` | N/A | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan validation split (90.30 GB) | 0.05s (20Hz) | :white_check_mark: |
 | nuPlan Test | `nuplan_test` | N/A | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan testing split (89.33 GB) | 0.05s (20Hz) | :white_check_mark: |
 | nuPlan Mini | `nuplan_mini` | `mini_train`, `mini_val`, `mini_test` | `boston`, `singapore`, `pittsburgh`, `las_vegas` | nuPlan mini training/validation/test splits (942/197/224 scenes, 7.96 GB) | 0.05s (20Hz) | :white_check_mark: |
-| View-of-Delft Train/TrainVal/Val | `nusc_trainval` | `train`, `train_val`, `val` | `delft` | View-of-Delft Prediction training and validation splits | 0.1s (10Hz) | :white_check_mark: |
-| View-of-Delft Test | `nusc_test` | `test` | `delft` | View-of-Delft test split, with annotations | 0.1s (10Hz) | :white_check_mark: |
+| View-of-Delft Train/TrainVal/Val | `vod_trainval` | `train`, `train_val`, `val` | `delft` | View-of-Delft Prediction training and validation splits | 0.1s (10Hz) | :white_check_mark: |
+| View-of-Delft Test | `vod_test` | `test` | `delft` | View-of-Delft Prediction test split | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Training | `waymo_train` | `train` | N/A | Waymo Open Motion Dataset `training` split | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Validation | `waymo_val` | `val` | N/A | Waymo Open Motion Dataset `validation` split | 0.1s (10Hz) | :white_check_mark: |
 | Waymo Open Motion Testing | `waymo_test` | `test` | N/A | Waymo Open Motion Dataset `testing` split | 0.1s (10Hz) | :white_check_mark: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ interaction = ["lanelet2==1.2.1"]
 lyft = ["l5kit==1.5.0"]
 nusc = ["nuscenes-devkit==1.1.9"]
 waymo = ["tensorflow==2.11.0", "waymo-open-dataset-tf-2-11-0", "intervaltree"]
+vod = ["vod-devkit==1.1.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/nvr-avg/trajdata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ interaction = ["lanelet2==1.2.1"]
 lyft = ["l5kit==1.5.0"]
 nusc = ["nuscenes-devkit==1.1.9"]
 waymo = ["tensorflow==2.11.0", "waymo-open-dataset-tf-2-11-0", "intervaltree"]
-vod = ["vod-devkit==1.1.0"]
+vod = ["vod-devkit==1.1.1"]
 
 [project.urls]
 "Homepage" = "https://github.com/nvr-avg/trajdata"

--- a/src/trajdata/dataset_specific/scene_records.py
+++ b/src/trajdata/dataset_specific/scene_records.py
@@ -34,6 +34,15 @@ class NuscSceneRecord(NamedTuple):
     data_idx: int
 
 
+class VODSceneRecord(NamedTuple):
+    token: str
+    name: str
+    location: str
+    length: str
+    desc: str
+    data_idx: int
+
+
 class LyftSceneRecord(NamedTuple):
     name: str
     length: str

--- a/src/trajdata/dataset_specific/vod/__init__.py
+++ b/src/trajdata/dataset_specific/vod/__init__.py
@@ -1,0 +1,1 @@
+from .vod_dataset import VODDataset

--- a/src/trajdata/dataset_specific/vod/vod_dataset.py
+++ b/src/trajdata/dataset_specific/vod/vod_dataset.py
@@ -1,0 +1,323 @@
+import warnings
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+import pandas as pd
+from tqdm import tqdm
+
+# from vod.eval.prediction.splits import NUM_IN_TRAIN_VAL
+from vod.map_expansion.map_api import VODMap, locations
+from vod.utils.splits import create_splits_scenes
+from vod.vod import VOD
+
+from trajdata.caching import EnvCache, SceneCache
+from trajdata.data_structures.agent import (
+    Agent,
+    AgentMetadata,
+    AgentType,
+    FixedExtent,
+    VariableExtent,
+)
+from trajdata.data_structures.environment import EnvMetadata
+from trajdata.data_structures.scene_metadata import Scene, SceneMetadata
+from trajdata.data_structures.scene_tag import SceneTag
+from trajdata.dataset_specific.raw_dataset import RawDataset
+from trajdata.dataset_specific.scene_records import VODSceneRecord
+from trajdata.dataset_specific.vod import vod_utils
+from trajdata.maps import VectorMap
+
+
+class VODDataset(RawDataset):
+    def compute_metadata(self, env_name: str, data_dir: str) -> EnvMetadata:
+        # We're using the VoD test split here.
+        # See TODO
+        # for full details on how the splits are obtained below.
+        all_scene_splits: Dict[str, List[str]] = create_splits_scenes()
+
+        train_scenes: List[str] = deepcopy(all_scene_splits["train"])
+
+        NUM_IN_TRAIN_VAL = round(0.8 * len(train_scenes))
+        all_scene_splits["train"] = train_scenes[NUM_IN_TRAIN_VAL:]
+        all_scene_splits["train_val"] = train_scenes[:NUM_IN_TRAIN_VAL]
+
+        if env_name == "vod_trainval":
+            vod_scene_splits: Dict[str, List[str]] = {
+                k: all_scene_splits[k] for k in ["train", "train_val", "val"]
+            }
+
+            # VoD possibilities are the Cartesian product of these
+            dataset_parts: List[Tuple[str, ...]] = [
+                ("train", "train_val", "val"),
+                ("delft",),
+            ]
+        elif env_name == "vod_test":
+            vod_scene_splits: Dict[str, List[str]] = {
+                k: all_scene_splits[k] for k in ["test"]
+            }
+
+            # VoD possibilities are the Cartesian product of these
+            dataset_parts: List[Tuple[str, ...]] = [
+                ("test",),
+                ("delft",),
+            ]
+
+            warnings.warn("Beware, vod_test has no annotations!")
+        elif env_name == "vod_mini":
+            vod_scene_splits: Dict[str, List[str]] = {
+                k: all_scene_splits[k] for k in ["mini_train", "mini_val"]
+            }
+
+            # VoD possibilities are the Cartesian product of these
+            dataset_parts: List[Tuple[str, ...]] = [
+                ("mini_train", "mini_val"),
+                ("delft",),
+            ]
+        else:
+            raise ValueError(f"Unknown VoD environment name: {env_name}")
+
+        # Inverting the dict from above, associating every scene with its data split.
+        vod_scene_split_map: Dict[str, str] = {
+            v_elem: k for k, v in vod_scene_splits.items() for v_elem in v
+        }
+
+        return EnvMetadata(
+            name=env_name,
+            data_dir=data_dir,
+            dt=vod_utils.VOD_DT,
+            parts=dataset_parts,
+            scene_split_map=vod_scene_split_map,
+            # The location names should match the map names used in
+            # the unified data cache.
+            map_locations=tuple(locations),
+        )
+
+    def load_dataset_obj(self, verbose: bool = False) -> None:
+        if verbose:
+            print(f"Loading {self.name} dataset...", flush=True)
+
+        if self.name == "vod_mini":
+            version_str = "v1.0-mini"
+        elif self.name == "vod_trainval":
+            version_str = "v1.0-trainval"
+        elif self.name == "vod_test":
+            version_str = "v1.0-test"
+
+        self.dataset_obj = VOD(version=version_str, dataroot=self.metadata.data_dir)
+
+    def _get_matching_scenes_from_obj(
+        self,
+        scene_tag: SceneTag,
+        scene_desc_contains: Optional[List[str]],
+        env_cache: EnvCache,
+    ) -> List[SceneMetadata]:
+        all_scenes_list: List[VODSceneRecord] = list()
+
+        scenes_list: List[SceneMetadata] = list()
+        for idx, scene_record in enumerate(self.dataset_obj.scene):
+            scene_token: str = scene_record["token"]
+            scene_name: str = scene_record["name"]
+            scene_desc: str = scene_record["description"].lower()
+            scene_location: str = self.dataset_obj.get(
+                "log", scene_record["log_token"]
+            )["location"]
+            scene_split: str = self.metadata.scene_split_map[scene_token]
+            scene_length: int = scene_record["nbr_samples"]
+
+            # Saving all scene records for later caching.
+            all_scenes_list.append(
+                VODSceneRecord(
+                    scene_token,
+                    scene_name,
+                    scene_location,
+                    scene_length,
+                    scene_desc,
+                    idx,
+                )
+            )
+
+            if scene_location in scene_tag and scene_split in scene_tag:
+                if scene_desc_contains is not None and not any(
+                    desc_query in scene_desc for desc_query in scene_desc_contains
+                ):
+                    continue
+
+                scene_metadata = SceneMetadata(
+                    env_name=self.metadata.name,
+                    name=scene_name,
+                    dt=self.metadata.dt,
+                    raw_data_idx=idx,
+                )
+                scenes_list.append(scene_metadata)
+
+        self.cache_all_scenes_list(env_cache, all_scenes_list)
+        return scenes_list
+
+    def _get_matching_scenes_from_cache(
+        self,
+        scene_tag: SceneTag,
+        scene_desc_contains: Optional[List[str]],
+        env_cache: EnvCache,
+    ) -> List[Scene]:
+        all_scenes_list: List[VODSceneRecord] = env_cache.load_env_scenes_list(
+            self.name
+        )
+
+        scenes_list: List[SceneMetadata] = list()
+        for scene_record in all_scenes_list:
+            (
+                scene_token,
+                scene_name,
+                scene_location,
+                scene_length,
+                scene_desc,
+                data_idx,
+            ) = scene_record
+            scene_split: str = self.metadata.scene_split_map[scene_token]
+
+            if scene_location.split("-")[0] in scene_tag and scene_split in scene_tag:
+                if scene_desc_contains is not None and not any(
+                    desc_query in scene_desc for desc_query in scene_desc_contains
+                ):
+                    continue
+
+                scene_metadata = Scene(
+                    self.metadata,
+                    scene_name,
+                    scene_location,
+                    scene_split,
+                    scene_length,
+                    data_idx,
+                    None,  # This isn't used if everything is already cached.
+                    scene_desc,
+                )
+                scenes_list.append(scene_metadata)
+
+        return scenes_list
+
+    def get_scene(self, scene_info: SceneMetadata) -> Scene:
+        _, _, _, data_idx = scene_info
+
+        scene_record = self.dataset_obj.scene[data_idx]
+        scene_token: str = scene_record["token"]
+        scene_name: str = scene_record["name"]
+        scene_desc: str = scene_record["description"].lower()
+        scene_location: str = self.dataset_obj.get("log", scene_record["log_token"])[
+            "location"
+        ]
+        scene_split: str = self.metadata.scene_split_map[scene_token]
+        scene_length: int = scene_record["nbr_samples"]
+
+        return Scene(
+            self.metadata,
+            scene_name,
+            scene_location,
+            scene_split,
+            scene_length,
+            data_idx,
+            scene_record,
+            scene_desc,
+        )
+
+    def get_agent_info(
+        self, scene: Scene, cache_path: Path, cache_class: Type[SceneCache]
+    ) -> Tuple[List[AgentMetadata], List[List[AgentMetadata]]]:
+        ego_agent_info: AgentMetadata = AgentMetadata(
+            name="ego",
+            agent_type=AgentType.VEHICLE,
+            first_timestep=0,
+            last_timestep=scene.length_timesteps - 1,
+            extent=FixedExtent(length=4.084, width=1.730, height=1.562),
+        )
+
+        agent_presence: List[List[AgentMetadata]] = [
+            [ego_agent_info] for _ in range(scene.length_timesteps)
+        ]
+
+        agent_data_list: List[pd.DataFrame] = list()
+        existing_agents: Dict[str, AgentMetadata] = dict()
+
+        all_frames: List[Dict[str, Union[str, int]]] = list(
+            vod_utils.frame_iterator(self.dataset_obj, scene)
+        )
+        frame_idx_dict: Dict[str, int] = {
+            frame_dict["token"]: idx for idx, frame_dict in enumerate(all_frames)
+        }
+        for frame_idx, frame_info in enumerate(all_frames):
+            for agent_info in vod_utils.agent_iterator(self.dataset_obj, frame_info):
+                if agent_info["instance_token"] in existing_agents:
+                    continue
+
+                if agent_info["category_name"] == "vehicle.ego":
+                    # Do not double-count the ego vehicle
+                    continue
+
+                if not agent_info["next"]:
+                    # There are some agents with only a single detection to them, we don't care about these.
+                    continue
+
+                agent: Agent = vod_utils.agg_agent_data(
+                    self.dataset_obj, agent_info, frame_idx, frame_idx_dict
+                )
+
+                for scene_ts in range(
+                    agent.metadata.first_timestep, agent.metadata.last_timestep + 1
+                ):
+                    agent_presence[scene_ts].append(agent.metadata)
+
+                existing_agents[agent.name] = agent.metadata
+
+                agent_data_list.append(agent.data)
+
+        ego_agent: Agent = vod_utils.agg_ego_data(self.dataset_obj, scene)
+        agent_data_list.append(ego_agent.data)
+
+        agent_list: List[AgentMetadata] = [ego_agent_info] + list(
+            existing_agents.values()
+        )
+
+        cache_class.save_agent_data(pd.concat(agent_data_list), cache_path, scene)
+
+        return agent_list, agent_presence
+
+    def cache_map(
+        self,
+        map_name: str,
+        cache_path: Path,
+        map_cache_class: Type[SceneCache],
+        map_params: Dict[str, Any],
+    ) -> None:
+        vod_map: VODMap = VODMap(dataroot=self.metadata.data_dir, map_name=map_name)
+
+        vector_map = VectorMap(map_id=f"{self.name}:{map_name}")
+        vod_utils.populate_vector_map(vector_map, vod_map)
+
+        map_cache_class.finalize_and_cache_map(cache_path, vector_map, map_params)
+
+    def cache_maps(
+        self,
+        cache_path: Path,
+        map_cache_class: Type[SceneCache],
+        map_params: Dict[str, Any],
+    ) -> None:
+        """
+        Stores rasterized maps to disk for later retrieval.
+
+        Below are the map origins (south western corner, in [lat, lon]) for each of
+        the 4 maps in VoD:
+            delft:       []
+
+        The dimensions of the maps are as follows ([width, height] in meters). They
+        can also be found in vod_utils.py
+            delft:       []
+        The rasterized semantic maps published with VoD v1.0 have a scale of 10px/m,
+        hence the above numbers are the image dimensions divided by 10.
+
+        VoD uses the same WGS 84 Web Mercator (EPSG:3857) projection as Google Maps/Earth.
+        """
+        for map_name in tqdm(
+            locations,
+            desc=f"Caching {self.name} Maps at {map_params['px_per_m']:.2f} px/m",
+            position=0,
+        ):
+            self.cache_map(map_name, cache_path, map_cache_class, map_params)

--- a/src/trajdata/dataset_specific/vod/vod_dataset.py
+++ b/src/trajdata/dataset_specific/vod/vod_dataset.py
@@ -5,8 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from tqdm import tqdm
-
-# from vod.eval.prediction.splits import NUM_IN_TRAIN_VAL
 from vod.map_expansion.map_api import VODMap, locations
 from vod.utils.splits import create_splits_scenes
 from vod.vod import VOD
@@ -30,16 +28,11 @@ from trajdata.maps import VectorMap
 
 class VODDataset(RawDataset):
     def compute_metadata(self, env_name: str, data_dir: str) -> EnvMetadata:
-        # We're using the VoD test split here.
-        # See TODO
+        # See https://github.com/tudelft-iv/view-of-delft-prediction-devkit/blob/main/src/vod/utils/splits.py
         # for full details on how the splits are obtained below.
         all_scene_splits: Dict[str, List[str]] = create_splits_scenes()
 
         train_scenes: List[str] = deepcopy(all_scene_splits["train"])
-
-        NUM_IN_TRAIN_VAL = round(0.8 * len(train_scenes))
-        all_scene_splits["train"] = train_scenes[NUM_IN_TRAIN_VAL:]
-        all_scene_splits["train_val"] = train_scenes[:NUM_IN_TRAIN_VAL]
 
         if env_name == "vod_trainval":
             vod_scene_splits: Dict[str, List[str]] = {
@@ -62,17 +55,16 @@ class VODDataset(RawDataset):
                 ("delft",),
             ]
 
-            warnings.warn("Beware, vod_test has no annotations!")
-        elif env_name == "vod_mini":
-            vod_scene_splits: Dict[str, List[str]] = {
-                k: all_scene_splits[k] for k in ["mini_train", "mini_val"]
-            }
+        # elif env_name == "vod_mini":
+        #     vod_scene_splits: Dict[str, List[str]] = {
+        #         k: all_scene_splits[k] for k in ["mini_train", "mini_val"]
+        #     }
 
-            # VoD possibilities are the Cartesian product of these
-            dataset_parts: List[Tuple[str, ...]] = [
-                ("mini_train", "mini_val"),
-                ("delft",),
-            ]
+        #     # VoD possibilities are the Cartesian product of these
+        #     dataset_parts: List[Tuple[str, ...]] = [
+        #         ("mini_train", "mini_val"),
+        #         ("delft",),
+        #     ]
         else:
             raise ValueError(f"Unknown VoD environment name: {env_name}")
 
@@ -96,12 +88,12 @@ class VODDataset(RawDataset):
         if verbose:
             print(f"Loading {self.name} dataset...", flush=True)
 
-        if self.name == "vod_mini":
-            version_str = "v1.0-mini"
-        elif self.name == "vod_trainval":
+        if self.name == "vod_trainval":
             version_str = "v1.0-trainval"
         elif self.name == "vod_test":
             version_str = "v1.0-test"
+        # elif self.name == "vod_mini":
+        #     version_str = "v1.0-mini"
 
         self.dataset_obj = VOD(version=version_str, dataroot=self.metadata.data_dir)
 

--- a/src/trajdata/dataset_specific/vod/vod_utils.py
+++ b/src/trajdata/dataset_specific/vod/vod_utils.py
@@ -1,0 +1,508 @@
+from typing import Any, Dict, Final, List, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from pyquaternion import Quaternion
+from scipy.spatial.distance import cdist
+from tqdm import tqdm
+from vod.map_expansion import arcline_path_utils
+from vod.map_expansion.map_api import VODMap
+from vod.vod import VOD
+
+from trajdata.data_structures import Agent, AgentMetadata, AgentType, FixedExtent, Scene
+from trajdata.maps import VectorMap
+from trajdata.maps.vec_map_elements import (
+    MapElementType,
+    PedCrosswalk,
+    PedWalkway,
+    Polyline,
+    RoadArea,
+    RoadLane,
+)
+from trajdata.utils import arr_utils, map_utils
+
+VOD_DT: Final[float] = 0.1
+
+
+def frame_iterator(vod_obj: VOD, scene: Scene) -> Dict[str, Union[str, int]]:
+    """Loops through all frames in a scene and yields them for the caller to deal with the information."""
+    curr_scene_token: str = scene.data_access_info["first_sample_token"]
+    while curr_scene_token:
+        frame = vod_obj.get("sample", curr_scene_token)
+
+        yield frame
+
+        curr_scene_token = frame["next"]
+
+
+def agent_iterator(vod_obj: VOD, frame_info: Dict[str, Any]) -> Dict[str, Any]:
+    """Loops through all annotations (agents) in a frame and yields them for the caller to deal with the information."""
+    ann_token: str
+    for ann_token in frame_info["anns"]:
+        ann_record = vod_obj.get("sample_annotation", ann_token)
+
+        agent_category: str = ann_record["category_name"]
+        if agent_category.startswith("vehicle") or agent_category.startswith("human"):
+            yield ann_record
+
+
+def get_ego_pose(vod_obj: VOD, frame_info: Dict[str, Any]) -> Dict[str, Any]:
+    cam_front_data = vod_obj.get("sample_data", frame_info["sample_data_token"])
+    ego_pose = vod_obj.get("ego_pose", cam_front_data["ego_pose_token"])
+    return ego_pose
+
+
+def agg_agent_data(
+    vod_obj: VOD,
+    agent_data: Dict[str, Any],
+    curr_scene_index: int,
+    frame_idx_dict: Dict[str, int],
+) -> Agent:
+    """Loops through all annotations of a specific agent in a scene and aggregates their data into an Agent object."""
+    if agent_data["prev"]:
+        print("WARN: This is not the first frame of this agent!")
+
+    translation_list = [np.array(agent_data["translation"][:3])[np.newaxis]]
+    agent_size = agent_data["size"]
+    yaw_list = [Quaternion(agent_data["rotation"]).yaw_pitch_roll[0]]
+
+    prev_idx: int = curr_scene_index
+    curr_sample_ann_token: str = agent_data["next"]
+    while curr_sample_ann_token:
+        agent_data = vod_obj.get("sample_annotation", curr_sample_ann_token)
+
+        translation = np.array(agent_data["translation"][:3])
+        heading = Quaternion(agent_data["rotation"]).yaw_pitch_roll[0]
+        curr_idx: int = frame_idx_dict[agent_data["sample_token"]]
+        if curr_idx > prev_idx + 1:
+            fill_time = np.arange(prev_idx + 1, curr_idx)
+            xs = np.interp(
+                x=fill_time,
+                xp=[prev_idx, curr_idx],
+                fp=[translation_list[-1][0, 0], translation[0]],
+            )
+            ys = np.interp(
+                x=fill_time,
+                xp=[prev_idx, curr_idx],
+                fp=[translation_list[-1][0, 1], translation[1]],
+            )
+            zs = np.interp(
+                x=fill_time,
+                xp=[prev_idx, curr_idx],
+                fp=[translation_list[-1][0, 2], translation[2]],
+            )
+            headings: np.ndarray = arr_utils.angle_wrap(
+                np.interp(
+                    x=fill_time,
+                    xp=[prev_idx, curr_idx],
+                    fp=np.unwrap([yaw_list[-1], heading]),
+                )
+            )
+            translation_list.append(np.stack([xs, ys, zs], axis=1))
+            yaw_list.extend(headings.tolist())
+
+        translation_list.append(translation[np.newaxis])
+        # size_list.append(agent_data['size'])
+        yaw_list.append(heading)
+
+        prev_idx = curr_idx
+        curr_sample_ann_token = agent_data["next"]
+
+    translations_np = np.concatenate(translation_list, axis=0)
+
+    # Doing this prepending so that the first velocity isn't zero (rather it's just the first actual velocity duplicated)
+    prepend_pos = translations_np[0, :2] - (
+        translations_np[1, :2] - translations_np[0, :2]
+    )
+    velocities_np = (
+        np.diff(
+            translations_np[:, :2], axis=0, prepend=np.expand_dims(prepend_pos, axis=0)
+        )
+        / VOD_DT
+    )
+
+    # Doing this prepending so that the first acceleration isn't zero (rather it's just the first actual acceleration duplicated)
+    prepend_vel = velocities_np[0] - (velocities_np[1] - velocities_np[0])
+    accelerations_np = (
+        np.diff(velocities_np, axis=0, prepend=np.expand_dims(prepend_vel, axis=0))
+        / VOD_DT
+    )
+
+    anno_yaws_np = np.expand_dims(np.stack(yaw_list, axis=0), axis=1)
+    # yaws_np = np.expand_dims(
+    #     np.arctan2(velocities_np[:, 1], velocities_np[:, 0]), axis=1
+    # )
+    # sizes_np = np.stack(size_list, axis=0)
+
+    # import matplotlib.pyplot as plt
+
+    # fig, ax = plt.subplots()
+    # ax.plot(translations_np[:, 0], translations_np[:, 1], color="blue")
+    # ax.quiver(
+    #     translations_np[:, 0],
+    #     translations_np[:, 1],
+    #     np.cos(anno_yaws_np),
+    #     np.sin(anno_yaws_np),
+    #     color="green",
+    #     label="annotated heading"
+    # )
+    # ax.quiver(
+    #     translations_np[:, 0],
+    #     translations_np[:, 1],
+    #     np.cos(yaws_np),
+    #     np.sin(yaws_np),
+    #     color="orange",
+    #     label="velocity heading"
+    # )
+    # ax.scatter([translations_np[0, 0]], [translations_np[0, 1]], color="red", label="Start", zorder=20)
+    # ax.legend(loc='best')
+    # plt.show()
+
+    agent_data_np = np.concatenate(
+        [translations_np, velocities_np, accelerations_np, anno_yaws_np], axis=1
+    )
+    last_timestep = curr_scene_index + agent_data_np.shape[0] - 1
+    agent_data_df = pd.DataFrame(
+        agent_data_np,
+        columns=["x", "y", "z", "vx", "vy", "ax", "ay", "heading"],
+        index=pd.MultiIndex.from_tuples(
+            [
+                (agent_data["instance_token"], idx)
+                for idx in range(curr_scene_index, last_timestep + 1)
+            ],
+            names=["agent_id", "scene_ts"],
+        ),
+    )
+
+    agent_type = vod_type_to_unified_type(agent_data["category_name"])
+    agent_metadata = AgentMetadata(
+        name=agent_data["instance_token"],
+        agent_type=agent_type,
+        first_timestep=curr_scene_index,
+        last_timestep=last_timestep,
+        extent=FixedExtent(
+            length=agent_size[1], width=agent_size[0], height=agent_size[2]
+        ),
+    )
+    return Agent(
+        metadata=agent_metadata,
+        data=agent_data_df,
+    )
+
+
+def vod_type_to_unified_type(vod_type: str) -> AgentType:
+    if vod_type.startswith("human"):
+        return AgentType.PEDESTRIAN
+    elif vod_type == "vehicle.bicycle":
+        return AgentType.BICYCLE
+    elif vod_type == "vehicle.motorcycle":
+        return AgentType.MOTORCYCLE
+    elif vod_type.startswith("vehicle"):
+        return AgentType.VEHICLE
+    else:
+        return AgentType.UNKNOWN
+
+
+def agg_ego_data(vod_obj: VOD, scene: Scene) -> Agent:
+    translation_list: List[np.ndarray] = list()
+    yaw_list: List[float] = list()
+    for frame_info in frame_iterator(vod_obj, scene):
+        ego_pose = get_ego_pose(vod_obj, frame_info)
+        yaw_list.append(Quaternion(ego_pose["rotation"]).yaw_pitch_roll[0])
+        translation_list.append(ego_pose["translation"])
+
+    translations_np: np.ndarray = np.stack(translation_list, axis=0)
+
+    # Doing this prepending so that the first velocity isn't zero (rather it's just the first actual velocity duplicated)
+    prepend_pos: np.ndarray = translations_np[0, :2] - (
+        translations_np[1, :2] - translations_np[0, :2]
+    )
+    velocities_np: np.ndarray = (
+        np.diff(
+            translations_np[:, :2], axis=0, prepend=np.expand_dims(prepend_pos, axis=0)
+        )
+        / VOD_DT
+    )
+
+    # Doing this prepending so that the first acceleration isn't zero (rather it's just the first actual acceleration duplicated)
+    prepend_vel: np.ndarray = velocities_np[0] - (velocities_np[1] - velocities_np[0])
+    accelerations_np: np.ndarray = (
+        np.diff(velocities_np, axis=0, prepend=np.expand_dims(prepend_vel, axis=0))
+        / VOD_DT
+    )
+
+    yaws_np: np.ndarray = np.expand_dims(np.stack(yaw_list, axis=0), axis=1)
+    # yaws_np = np.expand_dims(np.arctan2(velocities_np[:, 1], velocities_np[:, 0]), axis=1)
+
+    ego_data_np: np.ndarray = np.concatenate(
+        [translations_np, velocities_np, accelerations_np, yaws_np], axis=1
+    )
+    ego_data_df = pd.DataFrame(
+        ego_data_np,
+        columns=["x", "y", "z", "vx", "vy", "ax", "ay", "heading"],
+        index=pd.MultiIndex.from_tuples(
+            [("ego", idx) for idx in range(ego_data_np.shape[0])],
+            names=["agent_id", "scene_ts"],
+        ),
+    )
+
+    ego_metadata = AgentMetadata(
+        name="ego",
+        agent_type=AgentType.VEHICLE,
+        first_timestep=0,
+        last_timestep=ego_data_np.shape[0] - 1,
+        extent=FixedExtent(length=4.084, width=1.730, height=1.562),
+    )
+    return Agent(
+        metadata=ego_metadata,
+        data=ego_data_df,
+    )
+
+
+def extract_lane_center(vod_map: VODMap, lane_record) -> np.ndarray:
+    # Getting the lane center's points.
+    curr_lane = vod_map.arcline_path_3.get(lane_record["token"], [])
+    # TBD: temporarily change resolution_meters from 0.5 to 1.0. Need to add this as a parameter into vector_map_params.
+    lane_midline: np.ndarray = np.array(
+        arcline_path_utils.discretize_lane(curr_lane, resolution_meters=1.0)
+    )[:, :2]
+
+    # For some reason, VoD duplicates a few entries
+    # (likely how they're building their arcline representation).
+    # We delete those duplicate entries here.
+    duplicate_check: np.ndarray = np.where(
+        np.linalg.norm(np.diff(lane_midline, axis=0, prepend=0), axis=1) < 1e-10
+    )[0]
+    if duplicate_check.size > 0:
+        lane_midline = np.delete(lane_midline, duplicate_check, axis=0)
+
+    return lane_midline
+
+
+def extract_lane_and_edges(
+    vod_map: VODMap, lane_record
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    # Getting the bounding polygon vertices.
+    lane_polygon_obj = vod_map.get("polygon", lane_record["polygon_token"])
+    polygon_nodes = [
+        vod_map.get("node", node_token)
+        for node_token in lane_polygon_obj["exterior_node_tokens"]
+    ]
+    polygon_pts: np.ndarray = np.array(
+        [(node["x"], node["y"]) for node in polygon_nodes]
+    )
+
+    # Getting the lane center's points.
+    lane_midline: np.ndarray = extract_lane_center(vod_map, lane_record)
+
+    # Computing the closest lane center point to each bounding polygon vertex.
+    closest_midlane_pt: np.ndarray = np.argmin(cdist(polygon_pts, lane_midline), axis=1)
+    # Computing the local direction of the lane at each lane center point.
+    direction_vectors: np.ndarray = np.diff(
+        lane_midline,
+        axis=0,
+        prepend=lane_midline[[0]] - (lane_midline[[1]] - lane_midline[[0]]),
+    )
+
+    # Selecting the direction vectors at the closest lane center point per polygon vertex.
+    local_dir_vecs: np.ndarray = direction_vectors[closest_midlane_pt]
+    # Calculating the vectors from the the closest lane center point per polygon vertex to the polygon vertex.
+    origin_to_polygon_vecs: np.ndarray = polygon_pts - lane_midline[closest_midlane_pt]
+
+    # Computing the perpendicular dot product.
+    # See https://www.xarg.org/book/linear-algebra/2d-perp-product/
+    # If perp_dot_product < 0, then the associated polygon vertex is
+    # on the right edge of the lane.
+    perp_dot_product: np.ndarray = (
+        local_dir_vecs[:, 0] * origin_to_polygon_vecs[:, 1]
+        - local_dir_vecs[:, 1] * origin_to_polygon_vecs[:, 0]
+    )
+
+    # Determining which indices are on the right of the lane center.
+    on_right: np.ndarray = perp_dot_product < 0
+    # Determining the boundary between the left/right polygon vertices
+    # (they will be together in blocks due to the ordering of the polygon vertices).
+    idx_changes: int = np.where(np.roll(on_right, 1) < on_right)[0].item()
+
+    if idx_changes > 0:
+        # If the block of left/right points spreads across the bounds of the array,
+        # roll it until the boundary between left/right points is at index 0.
+        # This is important so that the following index selection orders points
+        # without jumps.
+        polygon_pts = np.roll(polygon_pts, shift=-idx_changes, axis=0)
+        on_right = np.roll(on_right, shift=-idx_changes)
+
+    left_pts: np.ndarray = polygon_pts[~on_right]
+    right_pts: np.ndarray = polygon_pts[on_right]
+
+    # Final ordering check, ensuring that left_pts and right_pts can be combined
+    # into a polygon without the endpoints intersecting.
+    # Reversing the one lane edge that does not match the ordering of the midline.
+    if map_utils.endpoints_intersect(left_pts, right_pts):
+        if not map_utils.order_matches(left_pts, lane_midline):
+            left_pts = left_pts[::-1]
+        else:
+            right_pts = right_pts[::-1]
+
+    # Ensuring that left and right have the same number of points.
+    # This is necessary, not for data storage but for later rasterization.
+    if left_pts.shape[0] < right_pts.shape[0]:
+        left_pts = map_utils.interpolate(left_pts, num_pts=right_pts.shape[0])
+    elif right_pts.shape[0] < left_pts.shape[0]:
+        right_pts = map_utils.interpolate(right_pts, num_pts=left_pts.shape[0])
+
+    return (
+        lane_midline,
+        left_pts,
+        right_pts,
+    )
+
+
+def extract_area(vod_map: VODMap, area_record) -> np.ndarray:
+    token_key: str
+    if "exterior_node_tokens" in area_record:
+        token_key = "exterior_node_tokens"
+    elif "node_tokens" in area_record:
+        token_key = "node_tokens"
+
+    polygon_nodes = [
+        vod_map.get("node", node_token) for node_token in area_record[token_key]
+    ]
+
+    return np.array([(node["x"], node["y"]) for node in polygon_nodes])
+
+
+def populate_vector_map(vector_map: VectorMap, vod_map: VODMap) -> None:
+    # Setting the map bounds.
+    vector_map.extent = np.array(
+        [
+            vod_map.explorer.canvas_min_x,
+            vod_map.explorer.canvas_min_y,
+            0.0,
+            vod_map.explorer.canvas_max_x,
+            vod_map.explorer.canvas_max_y,
+            0.0,
+        ]
+    )
+
+    overall_pbar = tqdm(
+        total=len(vod_map.lane)
+        + len(vod_map.lane_connector)
+        + len(vod_map.drivable_area)
+        + len(vod_map.ped_crossing)
+        + len(vod_map.walkway),
+        desc=f"Getting {vod_map.map_name} Elements",
+        position=1,
+        leave=False,
+    )
+
+    for lane_record in vod_map.lane:
+        center_pts, left_pts, right_pts = extract_lane_and_edges(vod_map, lane_record)
+
+        lane_record_token: str = lane_record["token"]
+
+        new_lane = RoadLane(
+            id=lane_record_token,
+            center=Polyline(center_pts),
+            left_edge=Polyline(left_pts),
+            right_edge=Polyline(right_pts),
+        )
+
+        for lane_id in vod_map.get_incoming_lane_ids(lane_record_token):
+            # Need to do this because some incoming/outgoing lane_connector IDs
+            # do not exist as lane_connectors...
+            if lane_id in vod_map._token2ind["lane_connector"]:
+                new_lane.prev_lanes.add(lane_id)
+
+        for lane_id in vod_map.get_outgoing_lane_ids(lane_record_token):
+            # Need to do this because some incoming/outgoing lane_connector IDs
+            # do not exist as lane_connectors...
+            if lane_id in vod_map._token2ind["lane_connector"]:
+                new_lane.next_lanes.add(lane_id)
+
+        # new_lane.adjacent_lanes_left.append(
+        #     l5_lane.adjacent_lane_change_left.id
+        # )
+        # new_lane.adjacent_lanes_right.append(
+        #     l5_lane.adjacent_lane_change_right.id
+        # )
+
+        # Adding the element to the map.
+        vector_map.add_map_element(new_lane)
+        overall_pbar.update()
+
+    for lane_record in vod_map.lane_connector:
+        # Unfortunately lane connectors in VoD have very simple exterior
+        # polygons which make extracting their edges quite difficult, so we
+        # only extract the centerline.
+        center_pts = extract_lane_center(vod_map, lane_record)
+
+        lane_record_token: str = lane_record["token"]
+
+        # Adding the element to the map.
+        new_lane = RoadLane(
+            id=lane_record_token,
+            center=Polyline(center_pts),
+        )
+
+        new_lane.prev_lanes.update(vod_map.get_incoming_lane_ids(lane_record_token))
+        new_lane.next_lanes.update(vod_map.get_outgoing_lane_ids(lane_record_token))
+
+        # new_lane.adjacent_lanes_left.append(
+        #     l5_lane.adjacent_lane_change_left.id
+        # )
+        # new_lane.adjacent_lanes_right.append(
+        #     l5_lane.adjacent_lane_change_right.id
+        # )
+
+        # Adding the element to the map.
+        vector_map.add_map_element(new_lane)
+        overall_pbar.update()
+
+    for drivable_area in vod_map.drivable_area:
+        for polygon_token in drivable_area["polygon_tokens"]:
+            if (
+                polygon_token is None
+                and str(None) in vector_map.elements[MapElementType.ROAD_AREA]
+            ):
+                # See below, but essentially VoD has two None polygon_tokens
+                # back-to-back, so we don't need the second one.
+                continue
+
+            polygon_record = vod_map.get("polygon", polygon_token)
+            polygon_pts = extract_area(vod_map, polygon_record)
+
+            # NOTE: VoD has some polygon_tokens that are None, although that
+            # doesn't stop the above get(...) function call so it's fine,
+            # just have to be mindful of this when creating the id.
+            new_road_area = RoadArea(
+                id=str(polygon_token), exterior_polygon=Polyline(polygon_pts)
+            )
+
+            for hole in polygon_record["holes"]:
+                polygon_pts = extract_area(vod_map, hole)
+                new_road_area.interior_holes.append(Polyline(polygon_pts))
+
+            # Adding the element to the map.
+            vector_map.add_map_element(new_road_area)
+            overall_pbar.update()
+
+    for ped_area_record in vod_map.ped_crossing:
+        polygon_pts = extract_area(vod_map, ped_area_record)
+
+        # Adding the element to the map.
+        vector_map.add_map_element(
+            PedCrosswalk(id=ped_area_record["token"], polygon=Polyline(polygon_pts))
+        )
+        overall_pbar.update()
+
+    for ped_area_record in vod_map.walkway:
+        polygon_pts = extract_area(vod_map, ped_area_record)
+
+        # Adding the element to the map.
+        vector_map.add_map_element(
+            PedWalkway(id=ped_area_record["token"], polygon=Polyline(polygon_pts))
+        )
+        overall_pbar.update()
+
+    overall_pbar.close()

--- a/src/trajdata/utils/env_utils.py
+++ b/src/trajdata/utils/env_utils.py
@@ -9,6 +9,11 @@ def get_raw_dataset(dataset_name: str, data_dir: str) -> RawDataset:
 
         return NuscDataset(dataset_name, data_dir, parallelizable=False, has_maps=True)
 
+    if "vod" in dataset_name:
+        from trajdata.dataset_specific.vod import VODDataset
+
+        return VODDataset(dataset_name, data_dir, parallelizable=True, has_maps=True)
+
     if "lyft" in dataset_name:
         from trajdata.dataset_specific.lyft import LyftDataset
 


### PR DESCRIPTION
This PR adds code for the recently-released [View-of-Delft Prediction](https://intelligent-vehicles.org/datasets/view-of-delft/) dataset to trajdata. This dataset contains scenarios (with many interactions between vehicles and VRUs) that are intended for the development of trajectory prediction and planning methods in urban environments. 