### PR TITLE
Fix XODR artificial road edge elevations

### DIFF
--- a/src/trajdata/dataset_specific/xodr/lane_processing.py
+++ b/src/trajdata/dataset_specific/xodr/lane_processing.py
@@ -111,6 +111,7 @@ def process_road(
             lane_offsets,
             center_x,
             center_y,
+            center_z,
             road_headings,
             road_edges,
         )
@@ -402,6 +403,7 @@ def _create_artificial_edges(
     lane_offsets: List[Tuple[int, List]],
     center_x: np.ndarray,
     center_y: np.ndarray,
+    center_z: np.ndarray,
     road_headings: np.ndarray,
     road_edges: Dict[str, np.ndarray],
 ) -> None:
@@ -412,6 +414,7 @@ def _create_artificial_edges(
         lane_offsets: List of (lane_id, width_sections) tuples
         center_x: X coordinates of road centerline
         center_y: Y coordinates of road centerline
+        center_z: Z coordinates of road centerline
         road_headings: Heading angles along the road
         road_edges: Dictionary to update with artificial edges
     """
@@ -441,7 +444,7 @@ def _create_artificial_edges(
             [
                 artificial_left_x,
                 artificial_left_y,
-                np.zeros_like(artificial_left_x),
+                center_z,
             ],
             axis=1,
         )
@@ -460,7 +463,7 @@ def _create_artificial_edges(
             [
                 artificial_right_x,
                 artificial_right_y,
-                np.zeros_like(artificial_right_x),
+                center_z,
             ],
             axis=1,
         )

--- a/tests/test_xodr_artificial_edges.py
+++ b/tests/test_xodr_artificial_edges.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from trajdata.dataset_specific.xodr.parser import parse_xodr
+
+
+def test_artificial_road_edges_preserve_road_elevation():
+    xodr = """<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <road name="r1" length="10.0" id="1" junction="-1">
+    <planView>
+      <geometry s="0.0" x="0.0" y="0.0" hdg="0.0" length="10.0"><line/></geometry>
+    </planView>
+    <elevationProfile>
+      <elevation s="0.0" a="76.0" b="0.5" c="0.0" d="0.0"/>
+    </elevationProfile>
+    <lanes>
+      <laneSection s="0.0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link/>
+            <width sOffset="0.0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>"""
+
+    parsed = parse_xodr(xodr, resolution=2.5)
+
+    real_right_edge = parsed.road_edges["1_R"]
+    artificial_left_edge = parsed.road_edges["1_L"]
+
+    assert np.allclose(artificial_left_edge[:, 2], real_right_edge[:, 2])
+    assert not np.allclose(artificial_left_edge[:, 2], 0.0)


### PR DESCRIPTION
  ## Summary
  
  Fix artificial road edges generated for OpenDRIVE roads that only have lanes on one side.
  
  Previously `_create_artificial_edges()` assigned `z = 0` to missing-side synthetic road edges. This is inconsistent
  with the rest of the XODR parser, where lane centers and real lane/road edges preserve the sampled road elevation
  from `<elevationProfile>`.
  
  This change passes the sampled `center_z` into artificial edge creation and uses it for synthetic left/right road
  edges.
  
  ## Why this matters
  
  Downstream consumers often reason about road-edge geometry in XY, but trajdata also builds `RoadEdgeKDTree` from full `xyz` points. If an artificial edge has `z = 0` while the road surface is tens of meters above that, nearest-edge queries can be affected by the incorrect 3D KDTree distance before downstream code performs XY-only distance checks.
  
  This showed up in AlpaSim validation after localizing XODR maps: lane geometry matched, but artificial road edges
  could still produce meter-scale road-edge validation discrepancies because the synthetic edge had the wrong
  elevation.
  
  ## Test
  
  Added a regression test with an elevated one-sided XODR road and verified that the artificial missing-side road edge preserves the same elevation as the real road edge.
  
  Run:
  
  `PYTHONPATH=/lustre/fs12/portfolios/av/projects/av_alpamayo_cosmos/users/guillermog/trajdata/src /lustre/fs12/
  portfolios/av/projects/av_alpamayo_cosmos/users/guillermog/alpasim/.venv/bin/python -m pytest tests/
  test_xodr_artificial_edges.py`