### PR TITLE
Fix invalid MADS wait lines and degenerate XODR sampling

### DIFF
--- a/src/trajdata/dataset_specific/mads/mads_utils.py
+++ b/src/trajdata/dataset_specific/mads/mads_utils.py
@@ -245,7 +245,9 @@ def find_wait_lines_parquet(df_wait_line: pd.DataFrame, clip_id: str) -> Dict[st
         ]  # Yield/Stop
         wait_lines_dict[wait_line_id]["implicit"] = df_wait_line[
             "WaitLine.is_implicit"
-        ][i]  # TODO: need to clarify what this specifically refers to
+        ][
+            i
+        ]  # TODO: need to clarify what this specifically refers to
     return wait_lines_dict
 
 
@@ -275,6 +277,17 @@ def interpolate_points(list1, list2):
     return longer, interpolated_points
 
 
+def _prepare_wait_lines(df_wait_line: pd.DataFrame) -> pd.DataFrame:
+    """Drop wait lines without map IDs and derive their associated lane IDs."""
+    df_wait_line = df_wait_line[df_wait_line["key.map_id"].notna()].reset_index(
+        drop=True
+    )
+    df_wait_line["lane.map_id"] = df_wait_line["key.map_id"].map(
+        lambda wait_line_id: wait_line_id.split("-")[1]
+    )
+    return df_wait_line
+
+
 def populate_vector_map(vector_map: VectorMap, map_root) -> None:
     # populate vector map from mads parquet files
     # map label schema: https://docs.nvda.ai/ndas/avdnn/latest/reference/maglev/data/clip/reference/schemas/labels.html?#map-derived-labels
@@ -294,12 +307,8 @@ def populate_vector_map(vector_map: VectorMap, map_root) -> None:
     )
     # TODO: invalid traffic light data from mads
     # df_traffic_light = pd.read_parquet(os.path.join(map_root, "traffic_light.parquet"))
-    df_wait_line = df_expand_json(
-        pd.read_parquet(os.path.join(map_root, "wait_line.parquet"))
-    )
-    # wait_line id is formatted as {wait_line_id}-{lane_id}
-    df_wait_line["lane.map_id"] = df_wait_line["key.map_id"].map(
-        lambda x: x.split("-")[1]
+    df_wait_line = _prepare_wait_lines(
+        df_expand_json(pd.read_parquet(os.path.join(map_root, "wait_line.parquet")))
     )
     clip_id = df_meta["key.clip_id"][0]
     all_lanes_dict = find_lane_polylines_parquet(

--- a/src/trajdata/dataset_specific/xodr/geometry.py
+++ b/src/trajdata/dataset_specific/xodr/geometry.py
@@ -15,7 +15,7 @@ import numpy as np
 
 def sample_centerline(
     road: ET.Element, resolution: float
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Sample the road centerline including elevation profile.
 
     This function processes both the planView (2D geometry) and elevationProfile
@@ -31,12 +31,13 @@ def sample_centerline(
         - y_coords: Array of y-coordinates in the road's coordinate system
         - z_coords: Array of z-coordinates (elevations) from elevation profile
         - headings: Array of heading angles in radians at each sample point
+        - s_coords: Array of actual longitudinal positions along the road
 
-        All arrays have the same length and empty arrays if no geometry is found.
+        All arrays have the same length, or are empty if no geometry is found.
     """
     plan_view = road.find("planView")
     if plan_view is None:
-        return np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0)
+        return np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0), np.zeros(0)
 
     # Parse elevation profile
     elevation_profile = road.find("elevationProfile")
@@ -58,6 +59,7 @@ def sample_centerline(
     center_ys: List[float] = []
     center_zs: List[float] = []
     headings: List[float] = []
+    center_ss: List[float] = []
     cumulative_s = 0.0
 
     for geom in plan_view.findall("geometry"):
@@ -115,6 +117,7 @@ def sample_centerline(
         center_ys.extend(ys.tolist())
         center_zs.extend(zs.tolist())
         headings.extend(hdgs.tolist())
+        center_ss.extend((cumulative_s + s_values).tolist())
 
         cumulative_s += geom_len
 
@@ -123,6 +126,7 @@ def sample_centerline(
         np.asarray(center_ys),
         np.asarray(center_zs),
         np.asarray(headings),
+        np.asarray(center_ss),
     )
 
 

--- a/src/trajdata/dataset_specific/xodr/lane_processing.py
+++ b/src/trajdata/dataset_specific/xodr/lane_processing.py
@@ -59,7 +59,9 @@ def process_road(
     is_junction_road = road.attrib.get("junction", "-1") != "-1"
 
     # Sample the road centerline
-    center_x, center_y, center_z, road_headings = sample_centerline(road, resolution)
+    center_x, center_y, center_z, road_headings, s_grid = sample_centerline(
+        road, resolution
+    )
     if center_x.size == 0:
         return min_xyz, max_xyz  # Nothing to do
 
@@ -74,9 +76,6 @@ def process_road(
     lane_offsets, lane_types, lane_directions = gather_lane_offsets_all_sections(
         lane_elem_lanes
     )
-
-    # Build width samples along s grid
-    s_grid = np.arange(center_x.shape[0]) * resolution
 
     # Apply lane offset to centerline
     center_x, center_y = _apply_lane_offset(
@@ -245,8 +244,10 @@ def _process_lane_geometry(
     # Process left side (positive IDs) and right side (negative IDs) separately
     # Both are processed from inside out (centerline -> outer edge)
     left_lane_ids = sorted([lid for lid, _ in lane_offsets if lid > 0])  # [1, 2, 3...]
-    right_lane_ids = sorted([lid for lid, _ in lane_offsets if lid < 0], reverse=True)  # [-1, -2, -3...]
-    
+    right_lane_ids = sorted(
+        [lid for lid, _ in lane_offsets if lid < 0], reverse=True
+    )  # [-1, -2, -3...]
+
     for is_left_side, side_ids in [(True, left_lane_ids), (False, right_lane_ids)]:
         if is_left_side:
             # For left lanes, start from reversed centerline since they flow opposite
@@ -321,7 +322,9 @@ def _process_lane_geometry(
         if side_ids:
             if is_left_side:
                 # Reverse back to road reference direction
-                edge = np.stack([current_edge_x[::-1], current_edge_y[::-1], center_z], axis=1)
+                edge = np.stack(
+                    [current_edge_x[::-1], current_edge_y[::-1], center_z], axis=1
+                )
                 road_edges[f"{road_id}_L"] = edge
             else:
                 edge = np.stack([current_edge_x, current_edge_y, center_z], axis=1)
@@ -372,7 +375,7 @@ def _create_single_lane_geometry(
 
     # Build 3D coordinates using actual elevation data
     xyz_center = np.stack([mid_x, mid_y, center_z], axis=1)
-    
+
     # Assign edges
     # For right lanes: current edge is inner (left), outer edge is outer (right)
     # For left lanes: with pre-reversed geometry, we use the same assignment
@@ -395,7 +398,6 @@ def _create_single_lane_geometry(
         is_left=lane_id > 0,
         direction=lane_direction,
     )
-
 
 
 def _create_artificial_edges(

--- a/src/trajdata/dataset_specific/xodr/parser.py
+++ b/src/trajdata/dataset_specific/xodr/parser.py
@@ -141,7 +141,7 @@ def _parse_crosswalks(
     road_id = road.attrib["id"]
 
     # Sample road centerline for s/t to xyz conversion
-    center_x, center_y, center_z, road_headings = sample_centerline(road, resolution)
+    center_x, center_y, center_z, road_headings, _ = sample_centerline(road, resolution)
     if center_x.size == 0:
         return min_xyz, max_xyz
 
@@ -272,7 +272,9 @@ def _parse_neighbor_lanes(root: ET.Element, lane_geoms: Dict[str, LaneGeom]) -> 
                             if direction == "forward":
                                 lg.left_neighbor_forward.add(f"{road_id}_{neighbor_id}")
                             elif direction == "backward":
-                                lg.left_neighbor_backward.add(f"{road_id}_{neighbor_id}")
+                                lg.left_neighbor_backward.add(
+                                    f"{road_id}_{neighbor_id}"
+                                )
 
                     # Right neighbor
                     right_elem = link_elem.find("right")
@@ -281,6 +283,10 @@ def _parse_neighbor_lanes(root: ET.Element, lane_geoms: Dict[str, LaneGeom]) -> 
                         if neighbor_id:
                             direction = right_elem.attrib.get("direction", "forward")
                             if direction == "forward":
-                                lg.right_neighbor_forward.add(f"{road_id}_{neighbor_id}")
+                                lg.right_neighbor_forward.add(
+                                    f"{road_id}_{neighbor_id}"
+                                )
                             elif direction == "backward":
-                                lg.right_neighbor_backward.add(f"{road_id}_{neighbor_id}")
+                                lg.right_neighbor_backward.add(
+                                    f"{road_id}_{neighbor_id}"
+                                )

--- a/src/trajdata/dataset_specific/xodr/traffic_elements.py
+++ b/src/trajdata/dataset_specific/xodr/traffic_elements.py
@@ -63,7 +63,7 @@ def parse_traffic_infrastructure(
         road_id = road.attrib["id"]
 
         # Get the road centerline (reference line)
-        center_x, center_y, center_z, road_headings = sample_centerline(
+        center_x, center_y, center_z, road_headings, _ = sample_centerline(
             road, resolution
         )
         if center_x.size == 0:

--- a/tests/test_mads_map_loading.py
+++ b/tests/test_mads_map_loading.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from trajdata.dataset_specific.mads.mads_utils import _prepare_wait_lines
+
+
+def test_prepare_wait_lines_drops_rows_without_map_ids():
+    wait_lines = pd.DataFrame(
+        {
+            "key.map_id": [None, "wait-42"],
+            "WaitLine.location": [[], [{"x": 0.0, "y": 0.0, "z": 0.0}]],
+        }
+    )
+
+    prepared = _prepare_wait_lines(wait_lines)
+
+    assert prepared["key.map_id"].tolist() == ["wait-42"]
+    assert prepared["lane.map_id"].tolist() == ["42"]
+    assert prepared.index.tolist() == [0]

--- a/tests/test_xodr_sampling.py
+++ b/tests/test_xodr_sampling.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from trajdata.dataset_specific.xodr.parser import parse_xodr
+
+
+def test_lane_widths_use_actual_samples_for_subresolution_roads():
+    xodr = """<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+  <road name="connector" length="4.47545209131181e-16" id="43" junction="60">
+    <planView>
+      <geometry s="0" x="3.4109831212174218" y="0.17676254182897455"
+                hdg="5.894318153732936" length="4.47545209131181e-16">
+        <line/>
+      </geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none"/></center>
+        <right>
+          <lane id="-1" type="driving">
+            <width sOffset="0" a="4.283505748483188" b="3.390282745438411"
+                   c="-36028797018964280" d="5.366876356306281e31"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>
+"""
+
+    parsed = parse_xodr(xodr, resolution=0.5)
+    lane = parsed.lanes["43_-1"]
+
+    assert np.isfinite(lane.center).all()
+    assert np.abs(lane.center).max() < 10.0
+    assert np.linalg.norm(lane.center[1] - lane.center[0]) < 1e-6


### PR DESCRIPTION
## Summary

1. Drop MADS wait-line rows without map IDs before deriving lane associations.
2. Preserve actual OpenDRIVE longitudinal sample coordinates for lane-width evaluation.
3. Add regressions for malformed ClipGT wait lines and sub-resolution connector roads.

## Validation

### Unit regressions

```shell
PYTHONPATH=src python -m pytest -q \
  tests/test_mads_map_loading.py \
  tests/test_xodr_sampling.py \
  tests/test_xodr_artificial_edges.py
```

Result: 3 passed.

### Real-scene regression

Downloaded real USDZ artifacts from the `public_2604` suite and compared the
complete `VectorMap` output from baseline `f515152` (this PR's direct parent)
against fixed commit `b071c3e`. The comparison canonicalized every map-element
field and byte-hashed every NumPy array; only derived KD/STR search-index objects
were excluded.

Nine unaffected scenes reproduced exactly: the canonical output files had an
empty diff and all 9 SHA-256 hashes matched.

1. `clipgt-00040136-e651-4abd-991d-0655ccda9430`
2. `clipgt-000525f6-3999-4812-9924-8adff40ca514`
3. `clipgt-00064c58-7047-4a53-8a36-b033baaaa5fb`
4. `clipgt-000a3a34-1031-4f90-9bc3-5b5c132fd1ed`
5. `clipgt-000a74ae-5c01-486e-ab6f-7f5160136357`
6. `clipgt-000e95f7-560d-4411-8069-b9f531ed3cd6`
7. `clipgt-0010ce77-d06e-43e6-bdaf-2cf8ab65cfe4`
8. `clipgt-001564ce-0019-4ec6-bb62-07ed2bd90f2e`
9. `clipgt-00169207-9da7-44c4-a67b-a925e77056ff`

The previously crashing scene was also reproduced and retested:

- Scene: `clipgt-c11ccf9f-65fc-4054-b945-d514c5fc7943`
- Baseline: `ValueError: Maximum allowed size exceeded`
- Fixed: loaded successfully and built search indices
- Output: 144 map elements and 13,970 numeric values
- Numeric validation: all values finite; maximum absolute value `623.5912`

This validates exact trajdata map-output reproduction; it does not claim full
simulator-rollout determinism.
